### PR TITLE
Add support for uploading remote images

### DIFF
--- a/samsungtvws/art.py
+++ b/samsungtvws/art.py
@@ -86,11 +86,11 @@ class SamsungTVArt(SamsungTVWSConnection):
             raise exceptions.ConnectionFailure(response)
 
         return self.connection
-        
+
     def get_uuid(self):
         self.art_uuid = str(uuid.uuid4())
         return self.art_uuid
-        
+
     def get_websocket_message(self):
         try:
             raw_data = self.connection.recv()
@@ -103,7 +103,7 @@ class SamsungTVArt(SamsungTVWSConnection):
         except websocket.WebSocketTimeoutException as e:
             raise exceptions.TimeoutError('Websocket Time out: {}'.format(e))
         return {}
-        
+
     def wait_for_response(self, wait_for_event, request_uuid=None):
         while True:
             data = self.get_websocket_message()
@@ -128,7 +128,7 @@ class SamsungTVArt(SamsungTVWSConnection):
     ) -> Optional[Dict[str, Any]]:
         if not request_data.get("id"):
             request_data["id"] = self.get_uuid()            #old api
-        request_data["request_id"] = request_data["id"]     #new api  
+        request_data["request_id"] = request_data["id"]     #new api
         self.send_command(ArtChannelEmitCommand.art_app_request(request_data))
         return self.wait_for_response(wait_for_event, request_data["id"])
 
@@ -175,7 +175,7 @@ class SamsungTVArt(SamsungTVWSConnection):
         )
         assert data
         return data
-        
+
     def set_favourite(self, content_id, status='on'):
         data = self._send_art_request(
             {   "request": "change_favorite",
@@ -185,7 +185,7 @@ class SamsungTVArt(SamsungTVWSConnection):
         )
         assert data
         return data
-        
+
     def get_artmode_settings(self, setting=''):
         '''
         setting can be any of 'brightness', 'color_temperature', 'motion_sensitivity',
@@ -206,7 +206,7 @@ class SamsungTVArt(SamsungTVWSConnection):
         )
         assert data
         return data
- 
+
     def set_auto_rotation_status(self, duration=0, type=True, category=2):
         '''
         duration is "off" or "number" where number is duration in minutes. set 0 for 'off'
@@ -254,7 +254,7 @@ class SamsungTVArt(SamsungTVWSConnection):
         )
         assert data
         return data
-        
+
     def get_color_temperature(self):
         try:
             data = self.get_artmode_settings('color_temperature')
@@ -271,7 +271,7 @@ class SamsungTVArt(SamsungTVWSConnection):
         )
         assert data
         return data
- 
+
     def get_thumbnail_list(self, content_id_list=[]):
         if isinstance(content_id_list, str):
             content_id_list=[content_id_list]
@@ -350,7 +350,7 @@ class SamsungTVArt(SamsungTVWSConnection):
             file_type = file_extension[1:]
             with open(file, 'rb') as f:
                 file = f.read()
-                
+
         file_size = len(file)
         file_type = file_type.lower()
         if file_type == "jpeg":
@@ -392,7 +392,7 @@ class SamsungTVArt(SamsungTVWSConnection):
         )
 
         art_socket_raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        art_socket = get_ssl_context().wrap_socket(art_socket_raw) if conn_info.get('secured', False) else art_socket_raw  
+        art_socket = get_ssl_context().wrap_socket(art_socket_raw) if conn_info.get('secured', False) else art_socket_raw
         art_socket.connect((conn_info["ip"], int(conn_info["port"])))
         art_socket.send(len(header).to_bytes(4, "big"))
         art_socket.send(header.encode("ascii"))
@@ -442,7 +442,7 @@ class SamsungTVArt(SamsungTVWSConnection):
                 "value": mode,
             }
         )
-        
+
     def get_rotation(self):
         data = self._send_art_request(
             {"request": "get_current_rotation"}

--- a/samsungtvws/art.py
+++ b/samsungtvws/art.py
@@ -4,19 +4,22 @@ SamsungTVWS - Samsung Smart TV WS API wrapper
 Copyright (C) 2019 DSR! <xchwarze@gmail.com>
 Copyright (C) 2021 Matthew Garrett <mjg59@srcf.ucam.org>
 Copyright (C) 2024 Nick Waterton <n.waterton@outlook.com>
+Copyright (C) 2025 Ed Leafe <ed@leafe.com>
 
 SPDX-License-Identifier: LGPL-3.0
 """
 
 from datetime import datetime
-import os
 import json
 import logging
 import random
+from pathlib import Path
 import socket
 from typing import Any, Dict, List, Optional, Union
+from urllib.parse import urlparse
 import uuid
 
+import requests
 import websocket
 
 from . import exceptions, helper
@@ -29,6 +32,7 @@ from .helper import get_ssl_context
 _LOGGING = logging.getLogger(__name__)
 
 ART_ENDPOINT = "com.samsung.art-app"
+CHUNK_SIZE = 64 * 1024 # 64K seems to work well
 
 
 class ArtChannelEmitCommand(SamsungTVCommand):
@@ -344,14 +348,79 @@ class SamsungTVArt(SamsungTVWSConnection):
 
         return thumbnail_data_dict if as_dict else list(thumbnail_data_dict.values()) if len(content_id_list) > 1 else thumbnail_data
 
-    def upload(self, file, matte="shadowbox_polar", portrait_matte="shadowbox_polar", file_type="png", date=None):
-        if isinstance(file, str):
-            file_name, file_extension = os.path.splitext(file)
-            file_type = file_extension[1:]
-            with open(file, 'rb') as f:
-                file = f.read()
 
-        file_size = len(file)
+    @staticmethod
+    def bytes_chunker(data):
+        """Return the bytes in CHUNK_SIZE pieces"""
+        pos = 0
+        total = len(data)
+        while pos < total:
+            end = pos + CHUNK_SIZE
+            yield data[pos: end]
+            pos = end
+
+    @staticmethod
+    def stream_chunker(url):
+        """Stream the image, yielding CHUNK_SIZE pieces"""
+        with requests.get(url, stream=True) as response:
+            response.raise_for_status()
+            for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
+                if chunk:  # filter out keep-alive chunks
+                    yield chunk
+
+    @staticmethod
+    def file_chunker(pth):
+        """Read the image file, yielding CHUNK_SIZE pieces"""
+        with open(pth, "rb") as f:
+            content = f.read(CHUNK_SIZE)
+            if content:
+                yield content
+            else:
+                # EOF
+                return
+
+    def upload(
+            self,
+            image,
+            matte="shadowbox_polar",
+            portrait_matte="shadowbox_polar",
+            file_type="png",
+            date=None
+    ):
+        """
+        Handle uploading images from different source types.
+
+        An image can be one of:
+            a) a file path to an image on the local disk
+            b) a url for an image on the web
+            c) a series of bytes being directly passed to this method
+
+        Both a) and b) will be passed as strings, so we use urlparse to see if it has a scheme,
+        which makes it a URL.
+
+        High quality images will be large, and reading them into memory can be inefficient, so we
+        define several methods above to yield their contents in CHUNK_SIZE pieces.
+        """
+        if isinstance(image, str):
+            pth = Path(image)
+            file_name = pth.stem
+            file_type = pth.suffix[1:]
+
+            # Check if the string is a URL for a remote image file
+            url_parts = urlparse(image)
+            if url_parts.scheme:
+                resp = requests.head(image)
+                file_size = resp.headers.get("Content-Length")
+                chunker = self.stream_chunker
+            else:
+                # It must be a file path
+                file_size = pth.stat().st_size
+                chunker = self.file_chunker
+        else:
+            # Received the raw bytes for an image. `file_type` must be passed if it is not `.png`
+            file_size = len(image)
+            chunker = self.bytes_chunker
+
         file_type = file_type.lower()
         if file_type == "jpeg":
             file_type = "jpg"
@@ -371,8 +440,8 @@ class SamsungTVArt(SamsungTVWSConnection):
                     "id": self.art_uuid,
                 },
                 "image_date": date,
-                "matte_id": matte or 'none',
-                "portrait_matte_id": portrait_matte or 'none',
+                "matte_id": matte or "none",
+                "portrait_matte_id": portrait_matte or "none",
                 "file_size": file_size,
             },
             wait_for_event="ready_to_use"
@@ -392,12 +461,13 @@ class SamsungTVArt(SamsungTVWSConnection):
         )
 
         art_socket_raw = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        art_socket = get_ssl_context().wrap_socket(art_socket_raw) if conn_info.get('secured', False) else art_socket_raw
+        art_socket = get_ssl_context().wrap_socket(art_socket_raw) if conn_info.get("secured", False) else art_socket_raw
         art_socket.connect((conn_info["ip"], int(conn_info["port"])))
         art_socket.send(len(header).to_bytes(4, "big"))
         art_socket.send(header.encode("ascii"))
-        art_socket.send(file)
-        #_LOGGING.info('sending: header length: {}, header: {}'.format(len(header).to_bytes(4, "big").hex(), header.encode("ascii")))
+        # Send the image contents in chunks
+        for chunk in chunker(image):
+            art_socket.send(chunk)
 
         data = self.wait_for_response("image_added")
         return data["content_id"] if data else None

--- a/samsungtvws/version.py
+++ b/samsungtvws/version.py
@@ -7,5 +7,6 @@
 # version 3.0.1 N Waterton 16th Jan 2025 added async_art_remove_mats.py example, fixed art_remove_mats.py
 # version 3.0.2 N Waterton 11th March 2025 - changed image compare function in async_update_from_directory.py, updated README and setup.py
 # version 3.0.3 N Waterton 24th march 2025 added asyncio.Lock to '_get_device_info' in async_art.py updated web_interface to fully async.
+# version 3.0.4 E Leafe 18th november 2025 added uploading images from urls, and uploading in chunks to reduce memory loads
 
-__version__ = '3.0.3'
+__version__ = '3.0.4'


### PR DESCRIPTION
I keep my images in an object store in the cloud, and wanted to display them in Art Mode on my TV, so this commit adds support for image URL uploading.

I also encountered some timeouts on the larger files, so I also added code to read an upload the images in chunks. My non-rigorous testing found that 64K was a good chunk size.
