### PR TITLE
Fix KeyError in process_event for API 5.x TVs

### DIFF
--- a/samsungtvws/async_art.py
+++ b/samsungtvws/async_art.py
@@ -154,9 +154,10 @@ class SamsungTVAsyncArt(SamsungTVWSAsyncConnection):
             data = json.loads(response["data"])
             sub_event = data.get("event", "*")
             if 'artmode_status' in sub_event:
-                self.art_mode = data['value'] == 'on'
+                # API 5.x may use 'status' instead of 'value'
+                self.art_mode = data.get('value', data.get('status', 'off')) == 'on'
             elif sub_event == 'art_mode_changed':
-                self.art_mode = data['status'] == 'on'
+                self.art_mode = data.get('status', 'off') == 'on'
             elif sub_event == 'go_to_standby':
                 self.art_mode = False
             elif 'wakeup' in sub_event:


### PR DESCRIPTION
## Summary
- API 5.x (2023+ models) may return `status` instead of `value` in artmode_status events
- Use `.get()` with fallback to handle both formats gracefully
- Also fixes potential KeyError in `art_mode_changed` event handling

## Problem
On 2023+ Samsung Frame TVs (API 5.x), the `artmode_status` event returns `status` field instead of `value`, causing a KeyError when trying to access `data['value']`.

## Solution
Use `.get()` with fallback: `data.get('value', data.get('status', 'off'))`

This handles both API 4.x (2022 models) and API 5.x (2023+ models) gracefully.

## Testing
Tested on:
- QN43LS03BAFXZA (2022 model, API 4.3.4.0)
- 2023 Frame TV (API 5.0.1.0)